### PR TITLE
Disabling the "Shake to undo" on iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-shake" version="0.5.3">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-shake" version="0.5.4">
     <name>Shake Gesture Detection</name>
     <author>Lee Crossley (http://ilee.co.uk/)</author>
     <description>Cordova Plugin to detect when a physical device performs a shake gesture.</description>
@@ -11,4 +11,18 @@
         <clobbers target="shake" />
     </js-module>
     <dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="CDVShake">
+                <param name="ios-package" value="CDVShake"/>
+                <param name="onload" value="true"/>
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/CDVShake.h" />
+        <source-file src="src/ios/CDVShake.m" />
+    </platform>
+
 </plugin>

--- a/src/ios/CDVShake.h
+++ b/src/ios/CDVShake.h
@@ -1,0 +1,21 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Cordova/CDVPlugin.h>
+
+@interface CDVShake : CDVPlugin
+@end

--- a/src/ios/CDVShake.m
+++ b/src/ios/CDVShake.m
@@ -1,0 +1,28 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVShake.h"
+#import <Cordova/CDV.h>
+
+@implementation CDVShake
+
+- (void)pluginInitialize
+{
+	[UIApplication sharedApplication].applicationSupportsShakeToEdit = NO;
+}
+
+@end


### PR DESCRIPTION
Disabling the "Shake to undo" feature of iOS by setting the application's applicationSupportsShakeToEdit property to NO.