### PR TITLE
Add native support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
-## Shake Gesture Detection for Cordova [![npm version](https://badge.fury.io/js/cordova-plugin-shake.svg)](http://badge.fury.io/js/cordova-plugin-shake)
+# Shake Gesture Detection for Cordova [![npm version](https://badge.fury.io/js/cordova-plugin-shake.svg)](http://badge.fury.io/js/cordova-plugin-shake)
 
 Apache Cordova / PhoneGap Plugin to detect when a physical device performs a shake gesture.
 
-This is based on a standalone JavaScript implementation I wrote last year ([gist](https://gist.github.com/leecrossley/4078996)).
+For iOS, the plugin uses the native shake detection.
+Fo all other platforms, it is based on a standalone JavaScript implementation I wrote last year ([gist](https://gist.github.com/leecrossley/4078996)).
 
 ## Install
 
 Requires Cordova v5.0.0 or above.
 
-#### Latest published version on npm
+### Latest published version on npm
 
-```
+```bash
 cordova plugin add cordova-plugin-shake
 ```
 
-#### Latest version from GitHub
+### Latest version from GitHub
 
-```
+```bash
 cordova plugin add https://github.com/leecrossley/cordova-plugin-shake.git
 ```
 
-### Usage
+## Usage
 
 You **do not** need to reference any JavaScript, the Cordova plugin architecture will add a shake object to your root automatically when you build.
 
 **NB:** There is no native component to this plugin but it depends on the device motion plugin (added when this plugin is added).
 
-### Example
+## Example
 
 ```js
 var onShake = function () {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cordova plugin add https://github.com/leecrossley/cordova-plugin-shake.git
 
 You **do not** need to reference any JavaScript, the Cordova plugin architecture will add a shake object to your root automatically when you build.
 
-**NB:** There is no native component to this plugin but it depends on the device motion plugin (added when this plugin is added).
+**NB:** For non-iOS platforms, there is no native component to this plugin but it depends on the device motion plugin (added when this plugin is added).
 
 ## Example
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,10 +8,36 @@
 	<engines>
 		<engine name="cordova" version=">=3.0.0" />
 	</engines>
-	<js-module src="www/shake.js" name="Shake">
-		<clobbers target="shake" />
-	</js-module>
-	<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	<platform name="amazon-fireos">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="android">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="blackberry10">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="browser">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="firefoxos">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
 	<platform name="ios">
 		<config-file target="config.xml" parent="/*">
 			<feature name="CDVShake">
@@ -19,8 +45,41 @@
 				<param name="onload" value="true"/>
 			</feature>
 		</config-file>
+		<js-module src="www/shakeNative.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
 		<header-file src="src/ios/CDVShake.h" />
 		<source-file src="src/ios/CDVShake.m" />
 		<hook type="after_plugin_install" src="src/ios/hooks/patchMainViewController.js" />
+	</platform>
+	<platform name="ubuntu">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="windows">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="windows8">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="wp7">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	</platform>
+	<platform name="wp8">
+		<js-module src="www/shake.js" name="Shake">
+			<clobbers target="shake" />
+		</js-module>
+		<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
 	</platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,28 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-shake" version="0.5.4">
-    <name>Shake Gesture Detection</name>
-    <author>Lee Crossley (http://ilee.co.uk/)</author>
-    <description>Cordova Plugin to detect when a physical device performs a shake gesture.</description>
-    <keywords>cordova, shake, gesture, accelerometer, acceleration, detection</keywords>
-    <engines>
-        <engine name="cordova" version=">=3.0.0" />
-    </engines>
-    <js-module src="www/shake.js" name="Shake">
-        <clobbers target="shake" />
-    </js-module>
-    <dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
-
-    <!-- ios -->
-    <platform name="ios">
-        <config-file target="config.xml" parent="/*">
-            <feature name="CDVShake">
-                <param name="ios-package" value="CDVShake"/>
-                <param name="onload" value="true"/>
-            </feature>
-        </config-file>
-
-        <header-file src="src/ios/CDVShake.h" />
-        <source-file src="src/ios/CDVShake.m" />
-    </platform>
-
+<plugin 
+	xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-shake" version="0.5.4">
+	<name>Shake Gesture Detection</name>
+	<author>Lee Crossley (http://ilee.co.uk/)</author>
+	<description>Cordova Plugin to detect when a physical device performs a shake gesture.</description>
+	<keywords>cordova, shake, gesture, accelerometer, acceleration, detection</keywords>
+	<engines>
+		<engine name="cordova" version=">=3.0.0" />
+	</engines>
+	<js-module src="www/shake.js" name="Shake">
+		<clobbers target="shake" />
+	</js-module>
+	<dependency id="cordova-plugin-device-motion" version=">=1.1.1" />
+	<platform name="ios">
+		<config-file target="config.xml" parent="/*">
+			<feature name="CDVShake">
+				<param name="ios-package" value="CDVShake"/>
+				<param name="onload" value="true"/>
+			</feature>
+		</config-file>
+		<header-file src="src/ios/CDVShake.h" />
+		<source-file src="src/ios/CDVShake.m" />
+		<hook type="after_plugin_install" src="src/ios/hooks/patchMainViewController.js" />
+	</platform>
 </plugin>

--- a/src/ios/CDVShake.h
+++ b/src/ios/CDVShake.h
@@ -20,5 +20,7 @@
 @interface CDVShake : CDVPlugin
 
 - (void)deviceShaken;
+- (void)startWatch:(CDVInvokedUrlCommand*)command;
+- (void)stopWatch:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CDVShake.h
+++ b/src/ios/CDVShake.h
@@ -18,4 +18,7 @@
 #import <Cordova/CDVPlugin.h>
 
 @interface CDVShake : CDVPlugin
+
+- (void)deviceShaken;
+
 @end

--- a/src/ios/CDVShake.m
+++ b/src/ios/CDVShake.m
@@ -20,19 +20,45 @@
 
 @implementation CDVShake
 
+NSString* callbackId = nil;
+    
 - (void)pluginInitialize
 {
-	[UIApplication sharedApplication].applicationSupportsShakeToEdit = NO;
+    NSLog(@"CDVShake::pluginInitialize");
 
-	// TODO: move
+	[UIApplication sharedApplication].applicationSupportsShakeToEdit = NO;
+    
+    // register for shake notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceShaken) name:@"CDVShakeDeviceShaken" object:nil];
-	// [[NSNotificationCenter defaultCenter] removeObserver:self name:@"CDVShakeDeviceShaken" object:nil];
+    }
+
+- (void)startWatch:(CDVInvokedUrlCommand*)command
+{
+	NSLog(@"CDVShake::startWatch");
+
+    // store callback id to be used, when device is shaken
+    callbackId = command.callbackId;
+}
+
+- (void)stopWatch:(CDVInvokedUrlCommand*)command
+{
+	NSLog(@"CDVShake::stopWatch");
+
+    // remove callback id
+    callbackId = nil;
 }
 
 - (void)deviceShaken
 {
-	// TODO: do real action
-    NSLog(@"deviceShaken");
+    NSLog(@"CDVShake::deviceShaken");
+    
+    // device was shaken
+    // inform app using the stored callback id
+    if (callbackId != nil) {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        [pluginResult setKeepCallbackAsBool:YES];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+    }
 }
 
 @end

--- a/src/ios/CDVShake.m
+++ b/src/ios/CDVShake.m
@@ -23,6 +23,16 @@
 - (void)pluginInitialize
 {
 	[UIApplication sharedApplication].applicationSupportsShakeToEdit = NO;
+
+	// TODO: move
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceShaken) name:@"CDVShakeDeviceShaken" object:nil];
+	// [[NSNotificationCenter defaultCenter] removeObserver:self name:@"CDVShakeDeviceShaken" object:nil];
+}
+
+- (void)deviceShaken
+{
+	// TODO: do real action
+    NSLog(@"deviceShaken");
 }
 
 @end

--- a/src/ios/hooks/patchMainViewController.js
+++ b/src/ios/hooks/patchMainViewController.js
@@ -1,0 +1,56 @@
+module.exports = function (ctx) {
+	var fs = ctx.requireCordovaModule('fs');
+	var path = ctx.requireCordovaModule('path');
+
+	function patchMainViewController(fileName) {
+		var data = fs.readFileSync(fileName, "utf8");
+
+		var toReplace = "@implementation MainViewController";
+		var replaceWith = "@implementation MainViewController\n" +
+			"\n" +
+			"// added by cordova-plugin-shake\n" +
+			"- (void) motionEnded:(UIEventSubtype)motion withEvent:(UIEvent*)event {\n" +
+			"\tif (event.type == UIEventTypeMotion && event.subtype == UIEventSubtypeMotionShake) {\n" +
+			"\t\t[[NSNotificationCenter defaultCenter] postNotificationName:@\"CDVShakeDeviceShaken\" object:self];\n" +
+			"\t}\n" +
+			"}";
+		if (data.indexOf("motionEnded") < 0) {
+			var result = data.replace(new RegExp(toReplace, "g"), replaceWith);
+			fs.writeFileSync(fileName, result, "utf8")
+			process.stdout.write(fileName + " patched\n");
+		}
+	}
+
+	function getProjectName(rootDir) {
+		var configFile = path.join(rootDir, "config.xml");
+		var contents = fs.readFileSync(configFile, "utf8");
+		if (contents) {
+			var lines = contents.split(/\r?\n/);
+			for (var i = 0; i < lines.length; i++) {
+				var line = lines[i].trim();
+				var pos1 = line.indexOf("<name>");
+				var pos2 = line.indexOf("</name>");
+				if (pos1 === 0 && pos2 > pos1) {
+					return line.slice(6, pos2);
+				}
+			}
+		}
+		throw ("name tag in file " + configFile + " not found");
+	}
+
+	var rootDir = ctx.opts.projectRoot;
+	if (rootDir) {
+		try {
+			// get project name from config.xml 
+			var projectName = getProjectName(rootDir);
+
+			var mainViewControllerFile = path.join("platforms", "ios", projectName, "Classes", "MainViewController.m");
+			if (!fs.existsSync(mainViewControllerFile)) {
+				throw "file " + mainViewControllerFile + " does not exist";
+			}
+			patchMainViewController(mainViewControllerFile);
+		} catch (e) {
+			process.stdout.write(e);
+		}
+	}
+}

--- a/www/shakeNative.js
+++ b/www/shakeNative.js
@@ -1,0 +1,35 @@
+module.exports = (function () {
+	"use strict";
+	var shake = {};
+
+	var shakeCallBack = null;
+
+	// Start watching for a shake gesture
+	shake.startWatch = function (onShake, _sensitivity, onError) {
+		if (typeof (onShake) !== "function") {
+			return;
+		}
+
+		cordova.exec(
+			onShake,
+			onError,
+			"CDVShake",
+			"startWatch",
+			[]
+		);
+		shakeCallBack = onShake;
+	};
+
+	// Stop watching for a shake gesture
+	shake.stopWatch = function () {
+		cordova.exec(
+			function () { }, // success
+			function () { }, // error
+			"CDVShake",
+			"stopWatch",
+			[]
+		);
+	};
+
+	return shake;
+})();


### PR DESCRIPTION
I added native support for iOS, which reacts faster than the JavaScript implementation. Moreover, it works also in the iOS Simulator (#26).

A little bit tricky is that I had to modify Cordova's `MainViewController.m` file for implementing the `motionEnded` event. I did this using a hook.